### PR TITLE
Changed subscription listeners to start after this.address is set

### DIFF
--- a/packages/8x.pay/src/pages/metamask-handler.js
+++ b/packages/8x.pay/src/pages/metamask-handler.js
@@ -29,7 +29,7 @@ class MetamaskHandler extends React.Component {
     this.checkPreviouslyAuthorized();
     bus.off('metamask:approval:requested');
     bus.off('status');
-    bus.off('user:authorization:true');
+    bus.off('user:authorization');
 
   }
 
@@ -74,16 +74,16 @@ class MetamaskHandler extends React.Component {
   checkStatus () {
     bus.on('status', (status) => {
       this.setState({
-        status: status,
-      })
+        status: status
+      });
     });
+
   }
 
   checkPreviouslyAuthorized () {
-    bus.on('user:authorization:true', () => {
-
+    bus.on('user:authorization', (boolean) => {
       this.setState({
-        authorized: true
+        authorized: boolean
       });
     });
 

--- a/packages/8x.pay/src/store/user.js
+++ b/packages/8x.pay/src/store/user.js
@@ -38,6 +38,7 @@ export default class UserStore {
             if(netId === '42') {
               this.address = accounts[0];
               bus.trigger('user:address:requested');
+              bus.trigger('authorization:status');
               bus.trigger('status', 'unlocked');
               bus.trigger('ERC20:balance:requested');
               bus.trigger('ETH:balance:requested');


### PR DESCRIPTION
Fixed bugs in subscription store listener, this is experienced when a user is logged out of metamask and then logs in after the prompt, the screen renders a return of null. 